### PR TITLE
Fix tabs and zones not hiding on overview or lock.

### DIFF
--- a/editor.ts
+++ b/editor.ts
@@ -181,7 +181,7 @@ export class Zone extends ZoneBase {
         super();
 
         this.createWidget(styleClass);
-        Main.uiGroup.add_child(this.widget);
+        Main.uiGroup.insert_child_above(this.widget, global.window_group);
     }
 
     public createWidget(styleClass: string = 'grid-preview') {
@@ -320,7 +320,7 @@ export class ZoneTab {
         this.buttonWidget.connect('button-press-event', (actor, event) => {
             Main.activateWindow(this.window);
         });
-        Main.uiGroup.add_child(this.buttonWidget);
+        Main.uiGroup.insert_child_above(this.buttonWidget, global.window_group);
     }
 
     destroy() {
@@ -609,7 +609,7 @@ export class ZoneAnchor {
         });
 
         //this.widgets.push(sizeButton);
-        Main.uiGroup.add_child(this.widget);
+        Main.uiGroup.insert_child_above(this.widget, global.window_group);
     }
 
     public adjustSizes() {


### PR DESCRIPTION
This pr fixes a bug found on Fedora 34 (gnome-shell 40). The tabs were always on top of everything, and showed even on lock screen or when viewing the overview. Now they don't do that anymore as they are children of the main window_group.

Old behaviour:
![Old behaviour](https://user-images.githubusercontent.com/10725286/131217837-45efedb2-8404-4593-b274-fad92ed36751.gif)

