### PR TITLE
Multiple monitors support

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -76,6 +76,8 @@ ts_library(
         ":snaptoneighbors_lib",
         ":editor_lib",
         ":tilespec_lib",
+        ":settings_lib",
+        ":monitors_lib",
     ],
 )
 ts_library(
@@ -90,6 +92,7 @@ ts_library(
             ":shellversion_lib",
             ":snaptoneighbors_lib",
             ":tilespec_lib",
+            ":monitors_lib",
         ],
 )
 ts_library(
@@ -174,6 +177,29 @@ ts_library(
         "@npm//chai",
         "@npm//jasmine",
     ],
+)
+
+ts_library(
+    name = "monitors_lib",
+    srcs = ["monitors.ts"],
+    tsconfig = "//:tsconfig.json",
+    deps = [
+        ":gnometypes_lib",
+        ":settings_lib",
+        ":tilespec_lib",
+        ":logging_lib"
+    ]
+)
+
+ts_library(
+    name = "settings_lib",
+    srcs = ["settings.ts"],
+    tsconfig = "//:tsconfig.json",
+        deps = [
+        ":logging_lib",
+        ":settings_data_lib",
+        ":tilespec_lib",
+    ]
 )
 
 jasmine_node_test(

--- a/app.ts
+++ b/app.ts
@@ -658,6 +658,12 @@ class App {
                         (<any>launcher).menu.addMenuItem(i));
                 }
             }
+
+            let sep = new PopupMenu.PopupSeparatorMenuItem();
+            (<any>launcher).menu.addMenuItem(sep);
+            (<any>launcher).menu.addMenuItem(editLayoutButton);
+            (<any>launcher).menu.addMenuItem(renameLayoutButton);
+            (<any>launcher).menu.addMenuItem(newLayoutButton);
         }
 
 

--- a/gnometypes.ts
+++ b/gnometypes.ts
@@ -501,7 +501,7 @@ export interface Window {
     is_attached_dialog(): void;
     is_client_decorated(): void;
     is_fullscreen(): void;
-    is_hidden(): void;
+    is_hidden(): boolean;
     is_monitor_sized(): void;
     is_on_all_workspaces(): void;
     is_on_primary_monitor(): void;

--- a/layouts-default.json
+++ b/layouts-default.json
@@ -1,11 +1,21 @@
 {
   "workspaces": [
-    {
-      "current": 3
-    },
-    {
-      "current": 2
-    }
+    [
+      {
+        "current": 3
+      },
+      {
+        "current": 2
+      }
+    ],
+    [
+      {
+        "current": 3
+      },
+      {
+        "current": 2
+      }
+    ]
   ],
   "definitions": [
     {

--- a/monitors.ts
+++ b/monitors.ts
@@ -1,0 +1,143 @@
+// GJS import system
+declare var imports: any;
+declare var global: any;
+
+const Main = imports.ui.main;
+const Meta = imports.gi.Meta;
+import {
+    WorkspaceManager as WorkspaceManagerInterface
+} from "./gnometypes";
+import { getIntSetting, SETTINGS_INSETS_PRIMARY_BOTTOM, SETTINGS_INSETS_PRIMARY_LEFT, SETTINGS_INSETS_PRIMARY_RIGHT, SETTINGS_INSETS_PRIMARY_TOP, SETTINGS_INSETS_SECONDARY_BOTTOM, SETTINGS_INSETS_SECONDARY_LEFT, SETTINGS_INSETS_SECONDARY_RIGHT, SETTINGS_INSETS_SECONDARY_TOP, } from "./settings";
+import * as tilespec from "./tilespec";
+
+// Getter for accesing "get_active_workspace" on GNOME <=2.28 and >= 2.30
+const WorkspaceManager: WorkspaceManagerInterface = (
+    global.screen || global.workspace_manager);
+
+export interface WorkArea {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+
+type MonitorTier = 'primary' | 'secondary';
+
+function getMonitorTier(monitor: Monitor): MonitorTier {
+    return isPrimaryMonitor(monitor) ? 'primary' : 'secondary';
+}
+
+interface Insets {
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+}
+
+function getMonitorInsets(tier: MonitorTier): Insets {
+    switch (tier) {
+        case 'primary':
+            return {
+                top: getIntSetting(SETTINGS_INSETS_PRIMARY_TOP),
+                bottom: getIntSetting(SETTINGS_INSETS_PRIMARY_BOTTOM),
+                left: getIntSetting(SETTINGS_INSETS_PRIMARY_LEFT),
+                right: getIntSetting(SETTINGS_INSETS_PRIMARY_RIGHT)
+            }; // Insets on primary monitor
+        case 'secondary':
+            return {
+                top: getIntSetting(SETTINGS_INSETS_SECONDARY_TOP),
+                bottom: getIntSetting(SETTINGS_INSETS_SECONDARY_BOTTOM),
+                left: getIntSetting(SETTINGS_INSETS_SECONDARY_LEFT),
+                right: getIntSetting(SETTINGS_INSETS_SECONDARY_RIGHT)
+            };
+        default:
+            throw new Error(`unknown monitor name ${JSON.stringify(tier)}`);
+    }
+}
+
+function getWindowsOfMonitor(monitor: Monitor) {
+    const monitors = activeMonitors();
+    let windows = global.get_window_actors().filter(function (w: any) {
+        return w.meta_window.get_window_type() != Meta.WindowType.DESKTOP
+            && w.meta_window.get_workspace() == WorkspaceManager.get_active_workspace()
+            && w.meta_window.showing_on_its_workspace()
+            && monitors[w.meta_window.get_monitor()] == monitor;
+    });
+
+    return windows;
+}
+
+function getMonitorKey(monitor: Monitor): string {
+    return monitor.x + ":" + monitor.width + ":" + monitor.y + ":" + monitor.height;
+}
+
+
+// TODO: This type is incomplete. Its definition is based purely on usage in
+// this file and may be missing methods from the Gnome object.
+export interface Monitor {
+    x: number;
+    y: number;
+    height: number;
+    width: number;
+};
+
+export function activeMonitors(): Monitor[] {
+    return Main.layoutManager.monitors;
+}
+
+/**
+ * Determine if the given monitor is the primary monitor.
+ * @param {Object} monitor The given monitor to evaluate.
+ * @returns {boolean} True if the given monitor is the primary monitor.
+ * */
+function isPrimaryMonitor(monitor: Monitor): boolean {
+    return Main.layoutManager.primaryMonitor.x == monitor.x && Main.layoutManager.primaryMonitor.y == monitor.y;
+}
+
+function getWorkAreaByMonitor(monitor: Monitor): WorkArea | null {
+    const monitors = activeMonitors();
+    for (let monitor_idx = 0; monitor_idx < monitors.length; monitor_idx++) {
+        let mon = monitors[monitor_idx];
+        if (mon.x == monitor.x && mon.y == monitor.y) {
+            return getWorkArea(monitor, monitor_idx);
+        }
+    }
+    return null;
+}
+
+/**
+ * @deprecated Use {@link workAreaRectByMonitorIndex} instead.
+ */
+function getWorkAreaByMonitorIdx(monitor_idx: number): WorkArea {
+    const monitors = activeMonitors();
+    let monitor = monitors[monitor_idx];
+    return getWorkArea(monitor, monitor_idx);
+}
+
+export function workAreaRectByMonitorIndex(monitorIndex: number): tilespec.Rect | null {
+    const monitor = activeMonitors()[monitorIndex];
+    if (!monitor) {
+        return null;
+    }
+    const waLegacy = getWorkArea(monitor, monitorIndex);
+
+    return (new tilespec.Rect(
+        new tilespec.XY(waLegacy.x, waLegacy.y),
+        new tilespec.Size(waLegacy.width, waLegacy.height)));
+}
+
+/**
+ * @deprecated Use {@link workAreaRectByMonitorIndex} instead.
+ */
+function getWorkArea(monitor: Monitor, monitor_idx: number): WorkArea {
+    const wkspace = WorkspaceManager.get_active_workspace();
+    const work_area = wkspace.get_work_area_for_monitor(monitor_idx);
+    const insets = getMonitorInsets(getMonitorTier(monitor));
+    return {
+        x: work_area.x + insets.left,
+        y: work_area.y + insets.top,
+        width: work_area.width - insets.left - insets.right,
+        height: work_area.height - insets.top - insets.bottom
+    };
+}

--- a/settings.ts
+++ b/settings.ts
@@ -1,0 +1,190 @@
+// GJS import system
+declare var imports: any;
+
+import * as tilespec from "./tilespec";
+import { BoolSettingName, NumberSettingName, StringSettingName } from './settings_data';
+import { log, setLoggingEnabled } from "./logging";
+
+// Globals
+export const SETTINGS_GRID_SIZES = 'grid-sizes';
+export const SETTINGS_AUTO_CLOSE = 'auto-close';
+export const SETTINGS_ANIMATION = 'animation';
+export const SETTINGS_SHOW_ICON = 'show-icon';
+export const SETTINGS_GLOBAL_PRESETS = 'global-presets';
+export const SETTINGS_MOVERESIZE_ENABLED = 'moveresize-enabled';
+export const SETTINGS_WINDOW_MARGIN = 'window-margin';
+export const SETTINGS_SHOW_TABS = 'show-tabs';
+export const SETTINGS_WINDOW_MARGIN_FULLSCREEN_ENABLED = 'window-margin-fullscreen-enabled';
+export const SETTINGS_MAX_TIMEOUT = 'max-timeout';
+export const SETTINGS_MAIN_WINDOW_SIZES = 'main-window-sizes';
+export const SETTINGS_INSETS_PRIMARY = 'insets-primary';
+export const SETTINGS_INSETS_PRIMARY_LEFT = 'insets-primary-left';
+export const SETTINGS_INSETS_PRIMARY_RIGHT = 'insets-primary-right';
+export const SETTINGS_INSETS_PRIMARY_TOP = 'insets-primary-top';
+export const SETTINGS_INSETS_PRIMARY_BOTTOM = 'insets-primary-bottom';
+export const SETTINGS_INSETS_SECONDARY = 'insets-secondary';
+export const SETTINGS_INSETS_SECONDARY_LEFT = 'insets-secondary-left';
+export const SETTINGS_INSETS_SECONDARY_RIGHT = 'insets-secondary-right';
+export const SETTINGS_INSETS_SECONDARY_TOP = 'insets-secondary-top';
+export const SETTINGS_INSETS_SECONDARY_BOTTOM = 'insets-secondary-bottom';
+export const SETTINGS_DEBUG = 'debug';
+
+export interface ParsedSettings {
+    [SETTINGS_GRID_SIZES]: tilespec.GridSize[];
+    [SETTINGS_AUTO_CLOSE]: any;
+    [SETTINGS_ANIMATION]: any;
+    [SETTINGS_SHOW_ICON]: any;
+    [SETTINGS_SHOW_TABS]: boolean;
+    [SETTINGS_GLOBAL_PRESETS]: any;
+    [SETTINGS_MOVERESIZE_ENABLED]: any;
+    [SETTINGS_WINDOW_MARGIN]: number;
+    [SETTINGS_WINDOW_MARGIN_FULLSCREEN_ENABLED]: boolean;
+    [SETTINGS_MAX_TIMEOUT]: any;
+    [SETTINGS_MAIN_WINDOW_SIZES]: Array<string>;
+    [SETTINGS_INSETS_PRIMARY]: number;
+    [SETTINGS_INSETS_PRIMARY_LEFT]: number;
+    [SETTINGS_INSETS_PRIMARY_RIGHT]: number;
+    [SETTINGS_INSETS_PRIMARY_TOP]: number;
+    [SETTINGS_INSETS_PRIMARY_BOTTOM]: number;
+    [SETTINGS_INSETS_SECONDARY]: number;
+    [SETTINGS_INSETS_SECONDARY_LEFT]: number;
+    [SETTINGS_INSETS_SECONDARY_RIGHT]: number;
+    [SETTINGS_INSETS_SECONDARY_TOP]: number;
+    [SETTINGS_INSETS_SECONDARY_BOTTOM]: number;
+    [SETTINGS_DEBUG]: any;
+}
+
+export const gridSettings: ParsedSettings = {
+    [SETTINGS_GRID_SIZES]: [],
+    [SETTINGS_AUTO_CLOSE]: null,
+    [SETTINGS_ANIMATION]: null,
+    [SETTINGS_SHOW_ICON]: null,
+    [SETTINGS_SHOW_TABS]: null,
+    [SETTINGS_GLOBAL_PRESETS]: null,
+    [SETTINGS_MOVERESIZE_ENABLED]: null,
+    [SETTINGS_WINDOW_MARGIN]: 0,
+    [SETTINGS_WINDOW_MARGIN_FULLSCREEN_ENABLED]: false,
+    [SETTINGS_MAX_TIMEOUT]: null,
+    [SETTINGS_MAIN_WINDOW_SIZES]: [],
+    [SETTINGS_SHOW_TABS]: true,
+    [SETTINGS_INSETS_PRIMARY]: 0,
+    [SETTINGS_INSETS_PRIMARY_LEFT]: 0,
+    [SETTINGS_INSETS_PRIMARY_RIGHT]: 0,
+    [SETTINGS_INSETS_PRIMARY_TOP]: 0,
+    [SETTINGS_INSETS_PRIMARY_BOTTOM]: 0,
+    [SETTINGS_INSETS_SECONDARY]: 0,
+    [SETTINGS_INSETS_SECONDARY_LEFT]: 0,
+    [SETTINGS_INSETS_SECONDARY_RIGHT]: 0,
+    [SETTINGS_INSETS_SECONDARY_TOP]: 0,
+    [SETTINGS_INSETS_SECONDARY_BOTTOM]: 0,
+    [SETTINGS_DEBUG]: null,
+};
+
+
+export interface SettingsObject {
+    get_boolean(name: BoolSettingName): boolean | undefined;
+
+    get_string(name: StringSettingName): string | undefined;
+
+    get_int(name: NumberSettingName): number | undefined;
+
+    connect(eventName: string, callback: () => void): any;
+
+    disconnect(c: any): void;
+};
+
+let mainWindowSizes = new Array();
+let settings: SettingsObject;
+let settingsConnection: any = null;
+let nbCols = 0;
+let nbRows = 0;
+
+function initGridSizes(configValue: string): void {
+    let gridSizes = tilespec.parseGridSizesIgnoringErrors(configValue);
+    if (gridSizes.length === 0) {
+        gridSizes = [
+            new tilespec.GridSize(8, 6),
+            new tilespec.GridSize(6, 4),
+            new tilespec.GridSize(4, 4),
+        ];
+    }
+    gridSettings[SETTINGS_GRID_SIZES] = gridSizes;
+}
+
+export function getBoolSetting(settingName: BoolSettingName): boolean {
+    const value = settings.get_boolean(settingName);
+    if (value === undefined) {
+        log("Undefined settings " + settingName);
+        gridSettings[settingName] = false;
+        return false;
+    } else {
+        gridSettings[settingName] = value;
+    }
+    return value;
+}
+
+export function getIntSetting(settingsValue: NumberSettingName) {
+    let iss = settings.get_int(settingsValue);
+    if (iss === undefined) {
+        log("Undefined settings " + settingsValue);
+        return 0;
+    } else {
+        return iss;
+    }
+}
+
+export function initSettings(changed_settings: () => void ) {
+    settings = imports.misc.extensionUtils.getSettings();
+    settingsConnection = settings.connect('changed', changed_settings);
+    setLoggingEnabled(getBoolSetting(SETTINGS_DEBUG));
+
+    log("Init settings");
+    const gridSizes = settings.get_string(SETTINGS_GRID_SIZES) || '';
+    log(SETTINGS_GRID_SIZES + " set to " + gridSizes);
+    initGridSizes(gridSizes);
+
+    getBoolSetting(SETTINGS_AUTO_CLOSE);
+    getBoolSetting(SETTINGS_ANIMATION);
+    getBoolSetting(SETTINGS_SHOW_ICON);
+    getBoolSetting(SETTINGS_SHOW_TABS);
+    getBoolSetting(SETTINGS_GLOBAL_PRESETS);
+    getBoolSetting(SETTINGS_MOVERESIZE_ENABLED);
+
+    gridSettings[SETTINGS_WINDOW_MARGIN] = getIntSetting(SETTINGS_WINDOW_MARGIN);
+    gridSettings[SETTINGS_WINDOW_MARGIN_FULLSCREEN_ENABLED] = getBoolSetting(SETTINGS_WINDOW_MARGIN_FULLSCREEN_ENABLED);
+
+    gridSettings[SETTINGS_MAX_TIMEOUT] = getIntSetting(SETTINGS_MAX_TIMEOUT);
+
+    // initialize these from settings, the first set of sizes
+    if (nbCols == 0 || nbRows == 0) {
+        nbCols = gridSettings[SETTINGS_GRID_SIZES][0].width;
+        nbRows = gridSettings[SETTINGS_GRID_SIZES][0].height;
+    }
+    const mainWindowSizesString = settings.get_string(SETTINGS_MAIN_WINDOW_SIZES);
+    log(SETTINGS_MAIN_WINDOW_SIZES + " settings found " + mainWindowSizesString);
+
+    mainWindowSizes = []
+    let mainWindowSizesArray = mainWindowSizesString?.split(",");
+
+    if(mainWindowSizesArray) {
+        for (var i in mainWindowSizesArray) {
+            let size = mainWindowSizesArray[i];
+            if (size.includes("/")) {
+                let fraction = size.split("/");
+                let ratio = parseFloat(fraction[0]) / parseFloat(fraction[1]);
+                mainWindowSizes.push(ratio);
+            } else {
+                mainWindowSizes.push(parseFloat(size));
+            }
+        }
+    }
+
+    log(SETTINGS_MAIN_WINDOW_SIZES + " set to " + mainWindowSizes);
+    log("Init complete, nbCols " + nbCols + " nbRows " + nbRows);
+
+}
+
+export function deinitSettings()
+{
+    settings.disconnect(settingsConnection);
+}


### PR DESCRIPTION
Hi everyone. 
I moved some types and functions in separate files to be able to implement this, so the first commit is just moving the code with no changes. You should be able to review only the second commit, which contains the real changes.

Since I do not have a secondary monitor, I used a dual-head virtual machine for testing. Hot-plugging a monitor should work, as should do different monitor dispositions.

When only one monitor is detected, the popup menu stays the same as before. When two or more monitors are detected, the popup menu is populated with a subsection for each monitor. I don't know if this is ideal. Also I am very open to suggestions (and also lots of tests, please!).

![multiple-monitors](https://user-images.githubusercontent.com/10725286/132979304-42eb30b8-34f6-4c3e-848f-4a0a1fea9b9f.gif)

I'm using this successfully in my virtual environment but more tests are required (from people running a older version of gnome, with more than two monitors, etc.).

Cheers!