### PR TITLE
Allowing Gnome 41 install (extension metadata)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
   "description": "Organize windows in customizable snap zones like FancyZones on windows.",
   "version": 1.1,
   "shell-version": [
-    "40"
+      "40",
+      "41"
   ],
   "url": "https://github.com/micahosborne/gSnap",
   "settings-schema": "org.gnome.shell.extensions.gsnap",


### PR DESCRIPTION
I haven't seen any obvious bug running on gnome 41.1